### PR TITLE
Add KafkaQueuingBackend initializer generator installing initializer into a Rails app

### DIFF
--- a/lib/generators/kafka_queuing_backend/install_generator.rb
+++ b/lib/generators/kafka_queuing_backend/install_generator.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'dotenv/load'
+require 'rails/generators'
+
+module KafkaQueuingBackend
+  module Generators
+    class InstallGenerator < Rails::Generators::Base
+      source_root File.expand_path('../templates', __dir__)
+      desc 'Creates the KafkaQueuingBackend initializer file'
+
+      def copy_initializer
+        template 'kafka_queuing_backend_initializer.rb',
+                 ENV.fetch('KAFKA_QUEUING_BACKEND_INITIALIZER_PATH', "#{Rails.root}/config/initializers/kafka_queuing_backend.rb")
+      end
+    end
+  end
+end

--- a/lib/generators/templates/kafka_queuing_backend_initializer.rb
+++ b/lib/generators/templates/kafka_queuing_backend_initializer.rb
@@ -1,0 +1,31 @@
+KafkaQueuingBackend.configure do | config |
+  config.provider   = :kafka
+  config.brokers    = ENV.fetch("KAFKA_HOST")
+  config.consumers  = [
+    {
+      name: 'first_consumer',
+      group: 'first_consumers_group',
+      topics: [
+        'test_topic_1',
+        'test_topic_2'
+      ]
+    },
+    {
+      name: 'second_consumer',
+      group: 'second_consumers_group',
+      topics: [
+        'test_topic_3',
+        'test_topic_4'
+      ]
+    },
+    {
+      name: 'third_consumer',
+      group: 'first_consumers_group',
+      topics: [
+        'test_topic_5',
+        'test_topic_2',
+        'test_topic_3'
+      ]
+    }
+  ]
+end

--- a/lib/kafka-queuing-backend.rb
+++ b/lib/kafka-queuing-backend.rb
@@ -1,11 +1,48 @@
 # frozen_string_literal: true
 
+require 'yaml'
+require 'dotenv/load'
 require 'kafka-queuing-backend/version'
 
 # == KafkaQueuingBackend
 #
 # Queuing Backend for Rails applications based on the Kafka event streaming platform.
 module KafkaQueuingBackend
+  raise "#{self.name} works inside a Rails applications only" unless defined?(Rails)
+
   class << self
+    attr_writer :provider, :brokers, :consumers
+
+    def configure
+      yield self
+    end
+
+    def provider
+      raise_missing_configuration_error(__method__) if @provider.nil?
+      @provider
+    end
+
+    def brokers
+      raise_missing_configuration_error(__method__) if @brokers.nil?
+      @brokers
+    end
+
+    def consumers
+      raise_missing_configuration_error(__method__) if @consumers.nil?
+      @consumers
+    end
+
+    private
+      def raise_missing_configuration_error(attribute)
+        raise ArgumentError, "The 'attribute' argument is missing" if attribute.nil?
+        raise MissingConfigurationError, attribute
+      end
+  end
+
+  class MissingConfigurationError < StandardError
+    def initialize(attribute)
+      raise ArgumentError, "The 'attribute' argument is missing" if attribute.nil?
+      super("The '#{attribute}' configuration is missing")#' in the #{KafkaQueuingBackend.config_path}' configuration file")
+    end
   end
 end

--- a/spec/dummy/.env.sample
+++ b/spec/dummy/.env.sample
@@ -1,0 +1,1 @@
+KAFKA_HOST=localhost:9092 

--- a/spec/dummy/config/initializers/kafka_queuing_backend.rb
+++ b/spec/dummy/config/initializers/kafka_queuing_backend.rb
@@ -1,0 +1,31 @@
+KafkaQueuingBackend.configure do | config |
+  config.provider   = :kafka
+  config.brokers    = ENV.fetch("KAFKA_HOST")
+  config.consumers  = [
+    {
+      name: 'first_consumer',
+      group: 'first_consumers_group',
+      topics: [
+        'test_topic_1',
+        'test_topic_2'
+      ]
+    },
+    {
+      name: 'second_consumer',
+      group: 'second_consumers_group',
+      topics: [
+        'test_topic_3',
+        'test_topic_4'
+      ]
+    },
+    {
+      name: 'third_consumer',
+      group: 'first_consumers_group',
+      topics: [
+        'test_topic_5',
+        'test_topic_2',
+        'test_topic_3'
+      ]
+    }
+  ]
+end

--- a/spec/lib/generators/kafka_queuing_backend/install_generator_spec.rb
+++ b/spec/lib/generators/kafka_queuing_backend/install_generator_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'generators/kafka_queuing_backend/install_generator'
+
+RSpec.describe KafkaQueuingBackend::Generators::InstallGenerator do
+  before :all do
+    remove_initializer
+  end
+
+  after :all do
+    remove_initializer
+    add_initializer
+  end
+
+  it 'installs initializer properly' do
+    described_class.start
+    expect(File.file?(initializer_file)).to be true
+  end
+end

--- a/spec/lib/kafka_queuing_backend_spec.rb
+++ b/spec/lib/kafka_queuing_backend_spec.rb
@@ -4,4 +4,65 @@ RSpec.describe KafkaQueuingBackend do
   it 'has version number' do
     expect(described_class::VERSION).not_to be_nil
   end
+
+  it 'is configurable' do
+    described_class.configure do | config |
+      expect(config).to eq(described_class)
+    end
+  end
+
+  context 'is configured' do
+    before(:all) do
+      described_class.configure do | config |
+        config.provider   = :kafka
+        config.brokers    = 'localhost:9092'
+        config.consumers  = [
+          {
+            name: 'first_consumer',
+            group: 'test_consumers_group',
+            topics: [
+              'test_topic_1'
+            ]
+          }
+        ]
+      end
+    end
+
+    it 'provider' do
+      expect(described_class.provider).not_to be_nil
+      expect(described_class.provider).not_to be_empty
+    end
+
+    it 'brokers' do
+      expect(described_class.brokers).not_to be_nil
+      expect(described_class.brokers).not_to be_empty
+    end
+
+    it 'consumers' do
+      expect(described_class.consumers).not_to be_nil
+      expect(described_class.consumers).not_to be_empty
+    end
+  end
+
+  context 'is not configured' do
+    before(:all) do
+      described_class.configure do | config |
+        config.provider = nil
+        config.brokers = nil
+        config.consumers = nil
+      end
+    end
+
+    it 'provider' do
+      expect { described_class.provider() }.to raise_error(KafkaQueuingBackend::MissingConfigurationError)
+    end
+
+    it 'brokers' do
+      expect { described_class.brokers() }.to raise_error(KafkaQueuingBackend::MissingConfigurationError)
+    end
+
+    it 'consumers' do
+      expect { described_class.consumers() }.to raise_error(KafkaQueuingBackend::MissingConfigurationError)
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,4 +7,14 @@ ENV['RAILS_ENV'] = 'test'
 require_relative '../spec/dummy/config/environment'
 ENV['RAILS_ROOT'] ||= "#{File.dirname(__FILE__)}../../../spec/dummy"
 
+# Support files
+Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].sort.each { |f| require f }
+
 require 'kafka-queuing-backend'
+
+RSpec.configure do |config|
+  config.include FileManager
+end
+
+include FileManager
+add_initializer

--- a/spec/support/file_manager.rb
+++ b/spec/support/file_manager.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'fileutils'
+
+module FileManager
+  def add_initializer
+    content = <<~RUBY
+      KafkaQueuingBackend.configure do | config |
+        config.provider   = :kafka
+        config.brokers    = ENV.fetch("KAFKA_HOST")
+        config.consumers  = [
+          {
+            name: 'first_consumer',
+            group: 'first_consumers_group',
+            topics: [
+              'test_topic_1',
+              'test_topic_2'
+            ]
+          },
+          {
+            name: 'second_consumer',
+            group: 'second_consumers_group',
+            topics: [
+              'test_topic_3',
+              'test_topic_4'
+            ]
+          },
+          {
+            name: 'third_consumer',
+            group: 'first_consumers_group',
+            topics: [
+              'test_topic_5',
+              'test_topic_2',
+              'test_topic_3'
+            ]
+          }
+        ]
+      end
+    RUBY
+    File.open(initializer_file, 'w+:UTF-8') { |f| f.write content } unless initializer_file.nil?
+  end
+
+  def initializer_file
+    "#{Rails.root}/config/initializers/kafka_queuing_backend.rb" if defined?(Rails)
+  end
+
+  def remove_initializer
+    FileUtils.remove_file initializer_file if File.file?(initializer_file)
+  end
+end


### PR DESCRIPTION
## Summary

To provide a better user experience we need to give our users a possibility to create an initializer running the `rails g kafka_queuing_backend:install` command. For that install initializer generator has to be added.

## Test Plan

1. I moved to the dummy application directory running the `cd spec/dummy` command within the gem directory.
2. Initialized the Kafka Queuing Backend running the `rails g kafka_queuing_backend:install` command.
3. Made sure the `create  config/initializers/kafka_queuing_backend.rb` has been printed in the terminal output and the `config/initializers/kafka_queuing_backend.rb` has been created.