### PR TITLE
Implement consumer receiving messages from queues using the kafka gem

### DIFF
--- a/lib/kafka-queuing-backend.rb
+++ b/lib/kafka-queuing-backend.rb
@@ -4,6 +4,8 @@ require 'yaml'
 require 'dotenv/load'
 require 'kafka-queuing-backend/version'
 require 'kafka-queuing-backend/producer_factory'
+require 'kafka-queuing-backend/consumer_factory'
+require 'kafka-queuing-backend/message_handler_factory'
 
 # == KafkaQueuingBackend
 #

--- a/lib/kafka-queuing-backend/consumer_factory.rb
+++ b/lib/kafka-queuing-backend/consumer_factory.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'kafka-queuing-backend/consumers/kafka_consumer'
+
+module KafkaQueuingBackend
+  class ConsumerFactory
+    class << self
+      def create(name:, group:, options: {})
+        case KafkaQueuingBackend.provider
+        when :kafka
+          kafka_consumer_options = {
+
+          }
+          KafkaConsumer.new(name: name, group: group, options: kafka_consumer_options)
+        else
+          raise "Unknown provider: #{KafkaQueuingBackend.provider}"
+        end
+      end
+    end
+  end
+end

--- a/lib/kafka-queuing-backend/consumers/kafka_consumer.rb
+++ b/lib/kafka-queuing-backend/consumers/kafka_consumer.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require 'kafka'
+require 'securerandom'
+require 'kafka-queuing-backend/message_handler_factory'
+
+class KafkaConsumer
+  attr_reader :id, :name, :group
+
+  def initialize(name:, group:, options: {})
+    @id       = SecureRandom.uuid
+    @name     = name
+    @group    = group
+    @options  = options
+    @thread   = Thread.current
+
+    # TODO: Map KafkaConsumer options to the kafka gem config
+    config    = Kafka::Config.new(
+      "group.id": group,
+      "bootstrap.servers": KafkaQueuingBackend.brokers,
+      "enable.auto.commit": !options.fetch(:disable_auto_commit, true),
+    )
+
+    @instance = Kafka::Consumer.new config
+  end
+
+  def subscribe(topics)
+    raise 'At least one topic required' if topics.nil? || topics.empty?
+
+    @instance.subscribe(topics)
+
+    Signal.trap(:INT)   { self.stop }
+    Signal.trap(:TERM)  { self.stop }
+
+    message_handler = KafkaQueuingBackend::MessageHandlerFactory.create
+
+    puts  "[#{@thread.object_id}]:\tThe '#{@name}' consumer "\
+          "is listening topic#{topics.count > 1 ? 's' : ''}: #{topics.join(', ')}"
+    puts  "Use Ctrl-C to stop"
+
+    loop do
+      @instance.poll do | message |
+        message_handler.handle(message)
+        @instance.commit(message, async: true) if @options.disable_auto_commit
+      rescue => error
+        Rails.logger.error "FAILED handling a message from '#{message.topic}' topic. Error: #{error}\n#{error.backtrace.join("\n")}"
+      end
+    ensure
+      break unless @thread.alive?
+    end
+  ensure
+    @instance.close unless @instance.nil?
+  end
+
+  def handle(message)
+    raise "The 'message' argument is required" if message.nil?
+  end
+
+  def stop
+    unless @thread.nil?
+      @thread.join(0.1)
+      @thread.terminate
+      sleep(0.001) while @thread.alive?
+      puts "\nThe '#{@name}' consumer has successfully been stopped"
+    else
+      puts "The thread doesn't exist"
+    end
+  end
+end

--- a/lib/kafka-queuing-backend/message_handler_factory.rb
+++ b/lib/kafka-queuing-backend/message_handler_factory.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'kafka-queuing-backend/message_handlers/kafka_default_message_handler'
+
+module KafkaQueuingBackend
+  class MessageHandlerFactory
+    class << self
+      def create(options: {})
+        case KafkaQueuingBackend.provider
+        when :kafka
+          if @kafka_default_message_handler.nil?
+            # TODO: Map factory options to the KafkaMessageHandler options
+            kafka_default_message_handler_options = {}
+            @kafka_default_message_handler = KafkaDefaultMessageHandler.new(options: kafka_default_message_handler_options)
+          end
+          @kafka_default_message_handler
+        else
+          raise "Unknown provider: #{KafkaQueuingBackend.provider}"
+        end
+      end
+    end
+  end
+end

--- a/lib/kafka-queuing-backend/message_handlers/kafka_default_message_handler.rb
+++ b/lib/kafka-queuing-backend/message_handlers/kafka_default_message_handler.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'json'
+
+class KafkaDefaultMessageHandler
+  def initialize(options: {})
+    @options = options
+  end
+
+  def handle(message)
+    message_payload = JSON.parse(message.payload, symbolize_names: true)
+    job             = message_payload.fetch(:job_class).constantize
+    arguments       = message_payload.fetch(:arguments)
+    job.perform_now(*arguments)
+  end
+end

--- a/spec/dummy/app/jobs/dummy_job.rb
+++ b/spec/dummy/app/jobs/dummy_job.rb
@@ -1,0 +1,7 @@
+class DummyJob < ApplicationJob
+  queue_as :default
+
+  def perform(*args)
+    puts "DummyJob.perform args: #{args}"
+  end
+end

--- a/spec/lib/kafka-queuing-backend/consumer_factory_spec.rb
+++ b/spec/lib/kafka-queuing-backend/consumer_factory_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'redpanda_helper'
+
+RSpec.describe KafkaQueuingBackend::ConsumerFactory do
+
+  before(:all) do
+    KafkaQueuingBackend.configure do | config |
+      config.provider = :kafka
+      config.brokers  = 'localhost:9092'
+    end
+  end
+
+  let(:test_consumer) {
+    {
+      name: 'test_consumer',
+      group: 'test_consumers_group',
+    }
+  }
+
+  it 'is defined' do
+    expect(described_class).not_to be_nil
+  end
+
+  it 'creates a consumer using the kafka gem' do
+    consumer = described_class.create(
+      name: test_consumer.fetch(:name),
+      group: test_consumer.fetch(:group),
+      options: { disable_auto_commit: true }
+    )
+    expect(consumer).not_to be_nil
+    expect(consumer.name).to eq(test_consumer.fetch(:name))
+  end
+end

--- a/spec/lib/kafka-queuing-backend/consumers/kafka_consumer_spec.rb
+++ b/spec/lib/kafka-queuing-backend/consumers/kafka_consumer_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'redpanda_helper'
+
+RSpec.describe KafkaConsumer do
+  let(:test_consumer) {
+    KafkaConsumer.new(
+      name: 'test_consumer',
+      group: 'test_consumers_group'
+    )
+  }
+
+  it 'is defined' do
+    expect(described_class).not_to be_nil
+  end
+
+  it 'successfully subscribes to a topic' do
+    Thread.new do
+      Thread.abort_on_exception = true
+      expect { test_consumer.subscribe(['default']) }.to output(/The 'test_consumer' consumer is listening topic: default/).to_stdout
+    end
+  end
+end

--- a/spec/lib/kafka-queuing-backend/message_handler_factory_spec.rb
+++ b/spec/lib/kafka-queuing-backend/message_handler_factory_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+RSpec.describe KafkaQueuingBackend::MessageHandlerFactory do
+  it 'is defined' do
+    expect(described_class).not_to be_nil
+  end
+
+  it 'creates a message handler handling the kafka gem messages' do
+    handler = described_class.create
+    expect(handler).not_to be_nil
+  end
+end

--- a/spec/lib/kafka-queuing-backend/message_handlers/kafka_default_message_handler_spec.rb
+++ b/spec/lib/kafka-queuing-backend/message_handlers/kafka_default_message_handler_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+RSpec.describe KafkaDefaultMessageHandler do
+  let(:test_message) {
+    double(:payload => '{"job_class":"DummyJob","job_id":"0b5a3e0c-a878-4321-afac-3a0aac7acba2","provider_job_id":"b3b83e82-f633-4c84-b4bd-1269f27d4589","queue_name":"test_topic","priority":null,"arguments":["{\"message\":\"Hello from test\"}"],"executions":0,"exception_executions":{},"locale":"en","timezone":"UTC","enqueued_at":"2022-07-12T22:22:12Z"}')
+  }
+
+  let(:test_handler) {
+    KafkaDefaultMessageHandler.new
+  }
+
+  it 'is defined' do
+    expect(described_class).not_to be_nil
+  end
+
+  it 'handles message properly' do
+    test_handler.handle(test_message)
+  end
+end


### PR DESCRIPTION
## Summary

To consume messages from a kafka broker topics:
- a consumer factory has to be implemented
_to avoid the dependency from a concrete consumer interacting with a Kafka broker and have a possibility to change it if needed_
- a consumer logic has to be encapsulated within a separate class
_to avoid code duplication creating new consumer instances using a concrete provider_
- a message handler factory has to be implemented
_to avoid the dependency from a concrete handler and have a possibility to change it if needed_
- a default message handler handling the kafka gem messages has to be implemented.
It has to create an ActiveJob instance invoking the `constantize` method on a message payload and perform the job passing parsed arguments to it.

## Test Plan
Ran tests with the 'rspec' command.