### PR TITLE
Add Queue Adapter producing messages to Kafka using ActiveJob

### DIFF
--- a/lib/active_job/queue_adapters/kafka_adapter.rb
+++ b/lib/active_job/queue_adapters/kafka_adapter.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require "kafka"
+require "securerandom"
+
+module ActiveJob
+  module QueueAdapters
+    # == Active Job Kafka adapter
+    #
+    # The Kafka adapter runs jobs with the Kafka event streaming platform.
+    #
+    # This is a custom queue adapter. It needs a Kafka server
+    # configured and running.
+    #
+    # To use this adapter, set queue adapter to +:kafka+:
+    #
+    #   config.active_job.queue_adapter = :kafka
+    #
+    # Or use the alias +:kqb+:
+    #
+    #   config.active_job.queue_adapter = :kqb
+    #
+    # To configure the adapter's Kafka brokers, set relevant attributes using the KafkaQueuingBackend.configure method
+    # in the config/initializers/kafka_queuing_backend.rb:
+    #
+    # KafkaQueuingBackend.configure do | config |
+    #   config.provider = :kafka
+    #   config.brokers  = 'localhost:9092'
+    # end
+    #
+    # The adapter uses a {kafka}[https://github.com/deadmanssnitch/kafka] client to produce jobs.
+    class KafkaAdapter
+      def enqueue(job) # :nodoc:
+        self.enqueue_at(job, nil)
+      end
+
+      def enqueue_at(job, timestamp) # :nodoc:
+        producer.produce(
+          timestamp: timestamp,
+          topic: job.queue_name,
+          payload: JobWrapper.new(job).data
+        )
+      end
+
+      class JobWrapper # :nodoc:
+        def initialize(job)
+          job.provider_job_id = SecureRandom.uuid
+          @job_data           = job.serialize
+        end
+
+        def perform
+          Base.execute @job_data
+        end
+
+        def data
+          @job_data.to_json
+        end
+      end
+
+      private
+        def producer
+          @producer ||= KafkaQueuingBackend::ProducerFactory.create(
+            name: ENV.fetch('KAFKA_PRODUCER_NAME', 'Kafka Queuing Backend ActiveJob Queue Adapter')
+          )
+          @producer
+        end
+    end
+
+    class KqbAdapter < KafkaAdapter
+    end
+  end
+end

--- a/lib/kafka-queuing-backend.rb
+++ b/lib/kafka-queuing-backend.rb
@@ -6,6 +6,7 @@ require 'kafka-queuing-backend/version'
 require 'kafka-queuing-backend/producer_factory'
 require 'kafka-queuing-backend/consumer_factory'
 require 'kafka-queuing-backend/message_handler_factory'
+require 'active_job/queue_adapters/kafka_adapter'
 
 # == KafkaQueuingBackend
 #

--- a/spec/lib/active_job/queue_adapters/kafka_adapter_spec.rb
+++ b/spec/lib/active_job/queue_adapters/kafka_adapter_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'redpanda_helper'
+
+RSpec.describe ActiveJob::QueueAdapters::KafkaTestAdapter do
+
+  subject(:test_job) { DummyJob.perform_later("test message") }
+
+  it 'is defined' do
+    expect(described_class).to_not be nil
+  end
+
+  it "enqueues the job" do
+    ActiveJob::Base.queue_adapter = :kafka_test
+    expect{ test_job }.to change(ActiveJob::Base.queue_adapter.enqueued_jobs, :size).by(1)
+  end
+end

--- a/spec/lib/active_job/queue_adapters/kafka_test_adapter.rb
+++ b/spec/lib/active_job/queue_adapters/kafka_test_adapter.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module ActiveJob
+  module QueueAdapters
+    class KafkaTestAdapter < ActiveJob::QueueAdapters::KafkaAdapter
+      def enqueued_jobs
+        if @enqueued_jobs.nil?
+            @enqueued_jobs = []
+        end
+        @enqueued_jobs
+      end
+
+      def enqueue(job)
+        super
+      end
+
+      def enqueue_at(job, timestamp)
+        super
+        enqueued_jobs << job
+      end
+    end
+
+    class KqpTestAdapter < KafkaTestAdapter
+    end
+  end
+end

--- a/spec/lib/active_job/queue_adapters/kqp_adapter_spec.rb
+++ b/spec/lib/active_job/queue_adapters/kqp_adapter_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'redpanda_helper'
+
+RSpec.describe ActiveJob::QueueAdapters::KafkaTestAdapter do
+
+  subject(:test_job) { DummyJob.perform_later("test message") }
+
+  it 'is defined' do
+    expect(described_class).to_not be nil
+  end
+
+  it "enqueues the job" do
+    ActiveJob::Base.queue_adapter = :kqp_test
+    expect{ test_job }.to change(ActiveJob::Base.queue_adapter.enqueued_jobs, :size).by(1)
+  end
+end

--- a/spec/redpanda_helper.rb
+++ b/spec/redpanda_helper.rb
@@ -27,5 +27,7 @@ RSpec.configure do |config|
     )
   end
 
+  require 'active_job/queue_adapters'
+  require_relative 'lib/active_job/queue_adapters/kafka_test_adapter'
   config.include ActiveJob::TestHelper
 end


### PR DESCRIPTION
## Summary

To produce messages to the Kafka (or Kafka compatible) event streaming platform topics the producer must be implemented.
The better way to do that is to implement a Queue Adapter and use it configuring a Rails application using Rails configurations and features.

## Test Plan

Ran tests invoking the `rspec` command and made sure that all tests are green.