### PR TITLE
Implement consumer pool to manage consumers instances

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,4 +1,5 @@
 --color
 --format documentation
 --order rand
+--seed 44193
 --require spec_helper

--- a/lib/kafka-queuing-backend.rb
+++ b/lib/kafka-queuing-backend.rb
@@ -7,6 +7,7 @@ require 'kafka-queuing-backend/producer_factory'
 require 'kafka-queuing-backend/consumer_factory'
 require 'kafka-queuing-backend/message_handler_factory'
 require 'active_job/queue_adapters/kafka_adapter'
+require 'kafka-queuing-backend/consumers/consumer_pool'
 
 # == KafkaQueuingBackend
 #

--- a/lib/kafka-queuing-backend/consumers/consumer_pool.rb
+++ b/lib/kafka-queuing-backend/consumers/consumer_pool.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require 'concurrent'
+require 'kafka-queuing-backend/consumer_factory'
+
+module KafkaQueuingBackend
+  class ConsumerPool
+    class << self
+      # Adds a consumer
+      def add(consumer)
+        raise ArgumentError, 'A consumer must be provided' if consumer.nil?
+
+        consumer_name = consumer.fetch(:name)
+
+        unless exists?(consumer_name)
+          thread = Thread.new do
+            Thread.current.name = consumer_name
+            Thread.current.thread_variable_set(:started_at, Time.now)
+            subscribe(consumer) unless exists?(consumer_name)
+          rescue => error
+            Rails.logger.error "FAILED subscribing '#{consumer_name}' consumer to '#{consumer.fetch(:topics)}' topics. \
+            Error: #{error}\n#{error.backtrace.join("\n")}"
+          end
+
+          threads.store(consumer_name, thread.join)
+        else
+          puts "The '#{consumer_name}' consumer has already been added"
+        end
+      end
+
+      # Stops the consumer
+      def stop(consumer_name)
+        return unless exists?(consumer_name)
+
+        begin
+          thread = threads.fetch(consumer_name)
+        rescue => error
+          puts "The '#{consumer_name}' consumer was not found. It's already stopped or hasn't been started. Error: #{error}\n#{error.backtrace.join("\n")}"
+        else
+          begin
+            self.terminate(thread)
+          rescue => error
+            Rails.logger.error "FAILED stopping the '#{consumer_name}' consumer. Error: #{error}\n#{error.backtrace.join("\n")}"
+          else
+            threads.delete(consumer_name)
+          end
+        end
+      end
+
+      # Stops all the consumers
+      def stop_all
+        threads.keys.each { | consumer_name | self.stop(consumer_name) }
+      end
+
+      # How many consumers are added already
+      def count
+        threads.size
+      end
+
+      def threads
+        if @threads.nil?
+          @threads = Concurrent::Hash.new
+        end
+        @threads
+      end
+
+      private
+        # Does consumer already added
+        def exists?(consumer_name)
+          threads.key?(consumer_name)
+        end
+
+        def terminate(thread)
+          thread.join(0.1)
+          thread.exit
+          sleep(0.001) while thread.alive?
+        end
+
+        def subscribe(consumer)
+          consumer_name     = consumer.fetch(:name)
+          consumers_group   = consumer.fetch(:group)
+          topics            = consumer.fetch(:topics)
+
+          consumer_instance = KafkaQueuingBackend::ConsumerFactory.create(
+            name: consumer_name,
+            group: consumers_group
+          )
+
+          consumer_instance.subscribe(topics)
+        ensure
+          consumer_instance.stop unless consumer_instance.nil?
+        end
+    end
+  end
+end

--- a/spec/lib/consumers/consumer_pool_spec.rb
+++ b/spec/lib/consumers/consumer_pool_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require 'redpanda_helper'
+
+RSpec.describe KafkaQueuingBackend::ConsumerPool do
+  it 'is defined' do
+    expect(described_class).to_not be nil
+  end
+
+  after(:each) do
+    described_class.stop_all
+  end
+
+  let(:test_consumer) {
+    if @test_consumer.nil?
+      @test_consumer = KafkaQueuingBackend.consumers.first
+    end
+    @test_consumer
+  }
+
+  let(:another_test_consumer) {
+    if @another_test_consumer.nil?
+      @another_test_consumer = KafkaQueuingBackend.consumers.drop(1).first
+    end
+    @another_test_consumer
+  }
+
+  it 'successfully adds a consumer only once' do
+    Thread.new do
+      Thread.abort_on_exception = true
+      expect { described_class.add(test_consumer) }.to change{ described_class.count }.by(1)
+      expect { described_class.add(test_consumer) }.to_not change { described_class.count }
+    end
+  end
+
+  it 'successfully stopps a consumer' do
+    Thread.new do
+      Thread.abort_on_exception = true
+      expect { described_class.add(test_consumer) }.to change{ described_class.count }.by(1)
+      expect { described_class.stop(test_consumer[:name]) }.to change{ described_class.count }.by(-1)
+    end
+  end
+
+  it 'successfully stopps all the consumers' do
+    Thread.new do
+      Thread.abort_on_exception = true
+      expect { described_class.add(test_consumer) }.to change{ described_class.count }.by(1)
+      expect { described_class.add(another_test_consumer) }.to change{ described_class.count }.by(1)
+      expect(described_class.count).to eq 2
+      described_class.stop_all
+      expect(described_class.count).to eq 0
+    end
+  end
+
+  it 'successfully stopps a consumer started in another thread' do
+    Thread.new do
+      Thread.abort_on_exception = true
+      Thread.new do
+        Thread.abort_on_exception = true
+        sleep 0.3
+        expect { described_class.add(test_consumer) }.to change{ described_class.count }.by(1)
+      end.join
+
+      Thread.new do
+        Thread.abort_on_exception = true
+        sleep 0.5
+        puts "count before stop: #{described_class.count}"
+        expect { described_class.stop(test_consumer[:name]) }.to change{ described_class.count }.by(-1)
+      end.join
+    end
+  end
+
+  it 'successfully stopps all the consumers started in another thread' do
+    Thread.new do
+      Thread.abort_on_exception = true
+      Thread.new do
+        Thread.abort_on_exception = true
+        expect { described_class.add(test_consumer) }.to change{ described_class.count }.by(1)
+        expect { described_class.add(another_test_consumer) }.to change{ described_class.count }.by(1)
+        expect(described_class.count).to eq 2
+      end.join
+
+      Thread.new do
+        Thread.abort_on_exception = true
+        sleep 0.1
+        described_class.stop_all
+        expect(described_class.count).to eq 0
+      end.join
+    end
+  end
+end


### PR DESCRIPTION
## Summary

To create consumers running asynchronously, the pool managing consumers must be implemented.
Each consumer must have a unique name and can be created only once in a separate thread joined to the main one. Stop consumer by name functionality must be implemented as well.

## Test Plan

Ran tests using the `rspec` command and made sure that all tests are green.