### PR TITLE
Implement rake task subscribing consumers by names

### DIFF
--- a/lib/kafka-queuing-backend.rb
+++ b/lib/kafka-queuing-backend.rb
@@ -3,6 +3,7 @@
 require 'yaml'
 require 'dotenv/load'
 require 'kafka-queuing-backend/version'
+require 'kafka-queuing-backend/railtie'
 require 'kafka-queuing-backend/producer_factory'
 require 'kafka-queuing-backend/consumer_factory'
 require 'kafka-queuing-backend/message_handler_factory'

--- a/lib/kafka-queuing-backend/railtie.rb
+++ b/lib/kafka-queuing-backend/railtie.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'rake'
+require 'rails/railtie'
+
+module KafkaQueuingBackend
+  # Load Rake tasks
+  class Railtie < Rails::Railtie
+    rake_tasks do
+        load 'tasks/kafka_queuing_backend_tasks.rake'
+    end
+  end
+end

--- a/lib/kafka-queuing-backend/task_definition/consumer.rb
+++ b/lib/kafka-queuing-backend/task_definition/consumer.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'kafka'
+
+module KafkaQueuingBackend
+  module TaskDefinition
+    class Consumer
+      class << self
+        def consume(consumers)
+          raise ArgumentError, "At least one consumer must be provided" if consumers.nil? || consumers.empty?
+
+          consumers.select do | consumer_name |
+            KafkaQueuingBackend.consumers.none? { | consumer | consumer_name == consumer[:name] }
+          end.each do | consumer_name |
+            puts "The '#{consumer_name}' consumer configuration was not found within the `config/initializers/kafka_queuing_backend.rb` file"
+          end
+
+          KafkaQueuingBackend.consumers.select { | consumer | consumers.include?(consumer[:name]) }.select do | consumer |
+            belongs_to_group = consumer.key?(:group)
+            puts "The #{:group} must be configured for the '#{consumer[:name]}' consumer configuration to receive messages" unless belongs_to_group
+            belongs_to_group
+
+          end.select do | consumer |
+            missing_topics = consumer.fetch(:topics, []).empty?
+            puts "At least one topic must be configured for the '#{consumer[:name]}' consumer configuration" if missing_topics
+            !missing_topics
+
+          end.each { | consumer | KafkaQueuingBackend::ConsumerPool.add(consumer) }
+        end
+      end
+    end
+  end
+end

--- a/lib/tasks/kafka_queuing_backend_tasks.rake
+++ b/lib/tasks/kafka_queuing_backend_tasks.rake
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "#{Rails.root}/config/environment"
+require 'kafka-queuing-backend/task_definition/consumer'
+
+namespace :kqb do
+  task :consume do |task, consumers|
+    execute_kafka_queuing_backend_consume(consumers)
+  end
+end
+
+namespace :kafka_queuing_backend do
+  task :consume do |task, consumers|
+    execute_kafka_queuing_backend_consume(consumers)
+  end
+end
+
+def execute_kafka_queuing_backend_consume(consumers)
+  KafkaQueuingBackend::TaskDefinition::Consumer.consume consumers.to_a
+end

--- a/spec/lib/tasks/kafka_queuing_backend_tasks_spec.rb
+++ b/spec/lib/tasks/kafka_queuing_backend_tasks_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+RSpec.describe 'Rake Tasks' do
+  describe 'task subscribing configured consumer to their topics' do
+    let(:consumers) {
+      KafkaQueuingBackend.consumers.map { | consumer | consumer.fetch(:name) }
+    }
+
+    let(:regex) {
+      /(configuration was not found)|(The group must be configured)|(At least one topic must be configured)|(FAILED)/
+    }
+
+    context 'invokes with correct argumets' do
+      it 'short task name' do
+        Thread.new do
+          Thread.abort_on_exception = true
+          expect { execute_kqb_consume(consumers) }.to output(/brokers are down/).to_stdout
+        end
+      end
+
+      it 'full task name' do
+        Thread.new do
+          Thread.abort_on_exception = true
+          expect { execute_kafka_queuing_backend_consume(consumers) }.to output(/brokers are down/).to_stdout
+        end
+      end
+    end
+
+    context 'fails when invalid arguments' do
+      context 'execute_kqb_consume method fails' do
+        it 'without arguments' do
+          Thread.new do
+            Thread.abort_on_exception = true
+            expect { execute_kqb_consume }.to raise_error(ArgumentError)
+          end
+        end
+
+        it 'empty array' do
+          Thread.new do
+            Thread.abort_on_exception = true
+            expect { execute_kqb_consume([]) }.to raise_error(ArgumentError)
+          end
+        end
+      end
+
+      context 'execute_kafka_queuing_backend_consume method' do
+        it 'without arguments' do
+          Thread.new do
+            Thread.abort_on_exception = true
+            expect { execute_kafka_queuing_backend_consume }.to raise_error(ArgumentError)
+          end
+        end
+
+        it 'empty array' do
+          Thread.new do
+            Thread.abort_on_exception = true
+            expect { execute_kafka_queuing_backend_consume([]) }.to raise_error(ArgumentError)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,8 +13,11 @@ Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].sort.each { |f| require f }
 require 'kafka-queuing-backend'
 
 RSpec.configure do |config|
+  config.include RakeUtils
   config.include FileManager
 end
 
 include FileManager
 add_initializer
+
+Rails.application.load_tasks if defined?(Rails)

--- a/spec/support/rake_utils.rb
+++ b/spec/support/rake_utils.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module RakeUtils
+  def execute_kqb_consume(consumers)
+    Rake::Task['kqb:consume'].execute consumers
+  end
+
+  def execute_kafka_queuing_backend_consume(consumers)
+    Rake::Task['kafka_queuing_backend:consume'].execute consumers
+  end
+end


### PR DESCRIPTION
## Summary

To to subscribe consumers receiving messages from the Kafka (or Kafka compatible) event streaming platform topics the rake task has to be implemented. Use the Consumer Pool to subscribe consumers.

## Test Plan

1. Started the Redpanda server running the following command: 
    ```
    docker run -d --pull=always --name=redpanda-1 --rm \
    -p 8081:8081 \
    -p 8082:8082 \
    -p 9092:9092 \
    -p 9644:9644 \
    docker.redpanda.com/vectorized/redpanda:latest \
    redpanda start \
    --overprovisioned \
    --smp 1  \
    --memory 1G \
    --reserve-memory 0M \
    --node-id 0 \
    --check=false 
    ```  
2. Opened the _Redpanda_ container terminal running the `docker exec -it redpanda-1 /bin/bash` command
3. Created the `test_topic_2` topic running the `rpk topic create test_topic_2` command
4. Within another terminal tab started the _first_consumer_ consumer running the `rails kqb:consume[first_consumer]` command
5. Switched back to the _Redpanda_ container tab
6. Produced a message:
    - Ran the `rpk topic produce test_topic_2` command
    - Pasted the following message: `{"job_class":"DummyJob","job_id":"0b5a3e0c-a878-4321-afac-3a0aac7acba2","provider_job_id":"b3b83e82-f633-4c84-b4bd-1269f27d4589","queue_name":"test_topic_2","priority":null,"arguments":["{\"message\":\"Hello from test\"}"],"executions":0,"exception_executions":{},"locale":"en","timezone":"UTC","enqueued_at":"2022-07-12T22:22:12Z"}`
    - Pressed enter
7. Switched back to the _first_consumer_ tab
8. Made sure the `DummyJob.perform args: ["{\"message\":\"Hello from test\"}"]` message has been printed within the output
_This message has been printed by the Dummy job's perform method._